### PR TITLE
Send Clojure maps nested in :extra as HashMaps

### DIFF
--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -70,7 +70,7 @@
                 "logger"      "happy.lucky"
                 "environment" "qa"
                 "culprit"     "123"
-                "extra"       {"one" [["two" 2]]}
+                "extra"       {"one" {"two" 2}}
                 "checksum"    "BD285A21"
                 "platform"    "clojure"
                 "breadcrumbs" {"values" [{"timestamp" 1473120000
@@ -102,7 +102,7 @@
                 "logger"      "happy.lucky"
                 "environment" "qa"
                 "culprit"     "123"
-                "extra"       {"one" [["two" 2]], "ex-info" 2}
+                "extra"       {"one" {"two" 2}, "ex-info" 2}
                 "checksum"    "BD285A21"
                 "platform"    "clojure"
                 "breadcrumbs" {"values" [{"timestamp" 1473120000
@@ -116,4 +116,41 @@
                 "fingerprint" ["{{ default }}", "nice"]}
                (-> output .toString json/parse-string
                    (dissoc "sentry.interfaces.Exception")
+                   (assoc-in ["sdk" "version"] "blah"))))))
+
+    (testing "an event with deeply-nested extra data"
+      (let [output (ByteArrayOutputStream.)
+            event' (-> event
+                       (assoc-in [:extra :one :three] {:iii [3]})
+                       (assoc-in [:extra :one :four] {:iv 4})
+                       (assoc-in [:extra :welp] {:nope "ok"}))
+            extra {"one" {"two" 2
+                          "three" {"iii" [3]}
+                          "four" {"iv" 4}}
+                   "welp" {"nope" "ok"}}]
+        (.marshall marshaller (#'core/map->event event') output)
+        (is (= {"release"     "v1.0.0"
+                "event_id"    "4c4fbea957a74c99808d2284306e6c98"
+                "message"     "ok"
+                "user"        {"id" 100}
+                "tags"        {"one" "2"}
+                "timestamp"   "2016-09-07T00:00:00"
+                "level"       "info"
+                "server_name" "example.com"
+                "logger"      "happy.lucky"
+                "environment" "qa"
+                "culprit"     "123"
+                "extra"       extra
+                "checksum"    "BD285A21"
+                "platform"    "clojure"
+                "breadcrumbs" {"values" [{"timestamp" 1473120000
+                                          "type"      "woo"
+                                          "level"     "ok"
+                                          "message"   "yes"
+                                          "category"  "maybe"
+                                          "data"      {"probably" "no"}}]}
+                "sdk"         {"name"    "raven-java"
+                               "version" "blah"}
+                "fingerprint" ["{{ default }}", "nice"]}
+               (-> output .toString json/parse-string
                    (assoc-in ["sdk" "version"] "blah"))))))))


### PR DESCRIPTION
Previously, if you passed something like

    {:foo {:bar "baz"}}

as `:extra` data, Sentry would receive it as

    {"foo": [["bar", "baz"]]}

There's not any real harm in this, it just looks a little surprising/clunky in the UI.

<img width="917" alt="Colorful 'after' picture" src="https://cloud.githubusercontent.com/assets/35545/23638673/0c36571a-02b1-11e7-957f-34d2eb868aaa.png">

This commit changes the handling of `:extra` maps so that nested map values are recursively turned into `java.util.HashMap` objects. This ensures Sentry receives those nested maps as JSON objects, which makes the data look a bit tighter in the UI.

<img width="922" alt="Black, white, and grainy 'before' picture" src="https://cloud.githubusercontent.com/assets/35545/23638677/11330ae2-02b1-11e7-9694-0248fe33fb15.png">

n.b.: It looks like the current behavior is a consequence of Clojure maps implementing both `java.lang.Iterable` and `java.util.Map`. The `JsonMarshaller` in raven-java[^1] treats Iterables and Maps as mutually exclusive; it just happens to check if serializable values are Iterable first.

[^1]: https://git.io/vyB79