### PR TITLE
Update to sentry-java 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# raven-clj
+# sentry-clj
 
 A thin wrapper around the
-[official Java library for Sentry](https://github.com/getsentry/raven-java/).
+[official Java library for Sentry](https://github.com/getsentry/sentry-java/).
 
 ## Usage
 
 ```clojure
-(require '[raven-clj.core :as raven])
+(require '[sentry-clj.core :as sentry])
 
 (def dsn
-  "https://blah:blee@sentry.io/bloo")
+  "https://public:private@sentry.io/1")
 
 (try
   (do-something-risky)
   (catch Exception e
-    (raven/send-event dsn {:throwable e})))
+    (sentry/send-event dsn {:throwable e})))
 ```
 
 ## Supported event keys
@@ -55,6 +55,7 @@ Supported keys of the map are:
 ## License
 
 Copyright © 2016 Coda Hale
+Copyright © 2017 Sentry
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Supported keys of the map are:
 
 ## License
 
-Copyright © 2016 Coda Hale
-Copyright © 2017 Sentry
+Copyright © 2016 Coda Hale, Sentry
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject com.codahale/raven-clj "0.2.1-SNAPSHOT"
+(defproject com.codahale/sentry-clj "0.2.1-SNAPSHOT"
   :description "A Clojure client for Sentry."
-  :url "https://github.com/codahale/raven-clj"
+  :url "https://github.com/codahale/sentry-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.7.0"]
                  [clj-time "0.13.0"]
-                 [com.getsentry.raven/raven "8.0.0"]
+                 [io.sentry/sentry "1.0.0"]
                  [ring/ring-core "1.5.1" :scope "provided"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]

--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -1,24 +1,24 @@
-(ns raven-clj.core
+(ns sentry-clj.core
   "A thin wrapper around the official Java library for Sentry."
   (:require [clj-time.coerce :as tc]
             [clojure.string :as string]
             [clojure.walk :as walk]
-            [raven-clj.internal :as internal])
+            [sentry-clj.internal :as internal])
   (:import (java.util HashMap Map UUID)
-           (com.getsentry.raven Raven)
-           (com.getsentry.raven.dsn Dsn)
-           (com.getsentry.raven.event Breadcrumb$Level
-                                      Breadcrumb$Type
-                                      BreadcrumbBuilder
-                                      Event
-                                      Event$Level
-                                      EventBuilder)
-           (com.getsentry.raven.event.interfaces ExceptionInterface)))
+           (io.sentry Sentry)
+           (io.sentry.dsn Dsn)
+           (io.sentry.event Breadcrumb$Level
+                            Breadcrumb$Type
+                            BreadcrumbBuilder
+                            Event
+                            Event$Level
+                            EventBuilder)
+           (io.sentry.event.interfaces ExceptionInterface)))
 
 (def ^:private instance
-  "A function which returns a Raven instance given a DSN."
+  "A function which returns a Sentry instance given a DSN."
   (memoize (fn [^String dsn]
-             (.createRavenInstance internal/factory (Dsn. dsn)))))
+             (.createSentryInstance internal/factory (Dsn. dsn)))))
 
 (defn- keyword->level
   "Converts a keyword into an event level."
@@ -116,19 +116,19 @@
   Supports sending throwables:
 
   ```
-  (raven/send-event dsn {:message   \"oh no\",
+  (sentry/send-event dsn {:message   \"oh no\",
                          :throwable e})
   ```
 
   Also supports interfaces with arbitrary values, e.g.:
 
   ```
-  (raven/send-event dsn {:message    \"oh no\",
+  (sentry/send-event dsn {:message    \"oh no\",
                          :interfaces {:user {:id    100
                                              :email \"test@example.com\"}}})
   ```
   "
   [dsn event]
   (let [e (map->event event)]
-    (.sendEvent ^Raven (instance dsn) e)
+    (.sendEvent ^Sentry (instance dsn) e)
     (-> e .getId (string/replace #"-" ""))))

--- a/src/sentry_clj/internal.clj
+++ b/src/sentry_clj/internal.clj
@@ -1,14 +1,14 @@
-(ns raven-clj.internal
+(ns sentry-clj.internal
   "Hacks on hacks on hacks on hacks again.
 
-  Some weird shit required to get the Raven lib to do the right thing."
+  Some weird shit required to get the Sentry lib to do the right thing."
   (:require [cheshire.factory :as fac]
             [cheshire.generate :as gen])
-  (:import (com.getsentry.raven RavenFactory DefaultRavenFactory)
-           (com.getsentry.raven.dsn Dsn)
-           (com.getsentry.raven.event.interfaces SentryInterface)
-           (com.getsentry.raven.marshaller.json JsonMarshaller
-                                                InterfaceBinding)))
+  (:import (io.sentry SentryClientFactory DefaultSentryClientFactory)
+           (io.sentry.dsn Dsn)
+           (io.sentry.event.interfaces SentryInterface)
+           (io.sentry.marshaller.json JsonMarshaller
+                                      InterfaceBinding)))
 
 (defrecord CljInterface [^String interface-name ^Object value]
   SentryInterface
@@ -20,8 +20,8 @@
   (writeInterface [_ jg interface]
     (gen/generate jg (:value interface) fac/default-date-format nil nil)))
 
-(def ^RavenFactory factory
-  (proxy [DefaultRavenFactory] []
+(def ^SentryClientFactory factory
+  (proxy [DefaultSentryClientFactory] []
     (createMarshaller [^Dsn dsn]
       (let [^JsonMarshaller marshaller (proxy-super createMarshaller dsn)]
         (.addInterfaceBinding marshaller CljInterface (->CljInterfaceBinding))

--- a/src/sentry_clj/ring.clj
+++ b/src/sentry_clj/ring.clj
@@ -1,6 +1,6 @@
-(ns raven-clj.ring
+(ns sentry-clj.ring
   "Ring utility functions."
-  (:require [raven-clj.core :as raven]
+  (:require [sentry-clj.core :as sentry]
             [ring.util.request :refer [request-url]]
             [ring.util.response :as response]))
 
@@ -58,5 +58,5 @@
             preprocess-fn
             (request->event e)
             (->> (postprocess-fn req)
-                 (raven/send-event dsn)))
+                 (sentry/send-event dsn)))
         (error-fn req e)))))

--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -1,17 +1,17 @@
-(ns raven-clj.core-test
+(ns sentry-clj.core-test
   (:require [cheshire.core :as json]
             [clj-time.coerce :as tc]
             [clj-time.core :as t]
             [clojure.test :refer :all]
-            [raven-clj.core :as core :refer :all]
-            [raven-clj.internal :as internal])
+            [sentry-clj.core :as core :refer :all]
+            [sentry-clj.internal :as internal])
   (:import (java.io ByteArrayOutputStream)
            (java.util UUID)
            (com.fasterxml.jackson.core JsonFactory)
-           (com.getsentry.raven.dsn Dsn)
-           (com.getsentry.raven.event BreadcrumbBuilder
-                                      Event$Level
-                                      EventBuilder)))
+           (io.sentry.dsn Dsn)
+           (io.sentry.event BreadcrumbBuilder
+                            Event$Level
+                            EventBuilder)))
 
 (deftest keyword->level-test
   (is (= Event$Level/DEBUG
@@ -32,6 +32,7 @@
   {:event-id     id
    :level        :info
    :release      "v1.0.0"
+   :dist         nil
    :environment  "qa"
    :logger       "happy.lucky"
    :timestamp    (t/date-time 2016 9 7)
@@ -60,6 +61,7 @@
       (let [output (ByteArrayOutputStream.)]
         (.marshall marshaller (#'core/map->event event) output)
         (is (= {"release"     "v1.0.0"
+                "dist"        nil
                 "event_id"    "4c4fbea957a74c99808d2284306e6c98"
                 "message"     "ok"
                 "user"        {"id" 100}
@@ -79,7 +81,7 @@
                                           "message"   "yes"
                                           "category"  "maybe"
                                           "data"      {"probably" "no"}}]}
-                "sdk"         {"name"    "raven-java"
+                "sdk"         {"name"    "sentry-java"
                                "version" "blah"}
                 "fingerprint" ["{{ default }}" "nice"]}
                (-> output .toString json/parse-string
@@ -92,6 +94,7 @@
                                                              {:ex-info 2}))
                                   (#'core/map->event)) output)
         (is (= {"release"     "v1.0.0"
+                "dist"        nil
                 "event_id"    "4c4fbea957a74c99808d2284306e6c98"
                 "message"     "ok"
                 "user"        {"id" 100}
@@ -112,7 +115,7 @@
                                           "message"   "yes"
                                           "category"  "maybe"
                                           "data"      {"probably" "no"}}]}
-                "sdk"         {"name"    "raven-java"
+                "sdk"         {"name"    "sentry-java"
                                "version" "blah"}
                 "fingerprint" ["{{ default }}" "nice"]}
                (-> output .toString json/parse-string
@@ -131,6 +134,7 @@
                     "welp" {"nope" "ok"}}]
         (.marshall marshaller (#'core/map->event event') output)
         (is (= {"release"     "v1.0.0"
+                "dist"        nil
                 "event_id"    "4c4fbea957a74c99808d2284306e6c98"
                 "message"     "ok"
                 "user"        {"id" 100}
@@ -150,7 +154,7 @@
                                           "message"   "yes"
                                           "category"  "maybe"
                                           "data"      {"probably" "no"}}]}
-                "sdk"         {"name"    "raven-java"
+                "sdk"         {"name"    "sentry-java"
                                "version" "blah"}
                 "fingerprint" ["{{ default }}" "nice"]}
                (-> output .toString json/parse-string

--- a/test/sentry_clj/internal_test.clj
+++ b/test/sentry_clj/internal_test.clj
@@ -1,14 +1,14 @@
-(ns raven-clj.internal-test
+(ns sentry-clj.internal-test
   (:require [cheshire.core :as json]
             [clj-time.coerce :as tc]
             [clj-time.core :as t]
             [clojure.test :refer :all]
-            [raven-clj.internal :refer :all])
+            [sentry-clj.internal :refer :all])
   (:import (java.io ByteArrayOutputStream)
            (java.util UUID)
            (com.fasterxml.jackson.core JsonFactory)
-           (com.getsentry.raven.dsn Dsn)
-           (com.getsentry.raven.event EventBuilder)))
+           (io.sentry.dsn Dsn)
+           (io.sentry.event EventBuilder)))
 
 (deftest interface-test
   (let [interface (->CljInterface "woo" {:blah 1})]
@@ -37,6 +37,7 @@
     (.setCompression marshaller false)
     (.marshall marshaller event output)
     (is (= {"release"     nil
+            "dist"        nil
             "event_id"    "4c4fbea957a74c99808d2284306e6c98"
             "message"     nil
             "woo"         {"blah" 1}
@@ -50,7 +51,7 @@
             "extra"       {}
             "checksum"    nil
             "platform"    "java"
-            "sdk"         {"name"    "raven-java"
+            "sdk"         {"name"    "sentry-java"
                            "version" "blah"}}
            (-> output .toString json/parse-string
                (assoc-in ["sdk" "version"] "blah"))))))

--- a/test/sentry_clj/ring_test.clj
+++ b/test/sentry_clj/ring_test.clj
@@ -1,8 +1,8 @@
-(ns raven-clj.ring-test
+(ns sentry-clj.ring-test
   (:require [clojure.test :refer :all]
             [mocko.core :refer :all]
-            [raven-clj.core :as raven]
-            [raven-clj.ring :refer :all]))
+            [sentry-clj.core :as sentry]
+            [sentry-clj.ring :refer :all]))
 
 (def e (Exception. "thing"))
 
@@ -54,7 +54,7 @@
                                                "REMOTE_ADDR" "127.0.0.1"}}
                       :user    {:ip_address "127.0.0.1"}}}
             handler (wrap-report-exceptions wrapped "dsn" {})]
-        (mock! #'raven/send-event {["dsn" event] nil})
+        (mock! #'sentry/send-event {["dsn" event] nil})
         (is (= {:status  500
                 :headers {"Content-Type" "text/html"}
                 :body    "<html><head><title>Error</title></head><body><p>Internal Server Error</p></body></html>"
@@ -80,6 +80,6 @@
                                             {:preprocess-fn  preprocess
                                              :postprocess-fn postprocess
                                              :error-fn       error})]
-        (mock! #'raven/send-event {["dsn" event] nil})
+        (mock! #'sentry/send-event {["dsn" event] nil})
         (is (= (assoc req :exception e)
                (handler req)))))))


### PR DESCRIPTION
`sentry-java` 1.0.0 is a renaming and large refactor of `raven-java`. This PR *only* switches over to the new library version and handles the renames.

As a followup, I'm going to submit one to use the new (simpler/cleaner) event APIs. As you're well aware, the APIs in `raven-java` were funktastic. 😄 

I'm also interested in pulling this into the `getsentry` organization if possible. I'd like to point Clojure users to this library and I don't want you to be burdened with issues.